### PR TITLE
Change 'RelationalOperator' class to String

### DIFF
--- a/src/AST/ExpressionStatement.java
+++ b/src/AST/ExpressionStatement.java
@@ -2,10 +2,10 @@ package AST;
 
 public class ExpressionStatement extends Statement {
   final private SimpleExpression simExpression;
-  final private RelationalOperator relOperator;
+  final private String relOperator;
   final private ExpressionStatement exprStatement;
 
-  public ExpressionStatement(SimpleExpression simExpr, RelationalOperator relOp, ExpressionStatement expr) {
+  public ExpressionStatement(SimpleExpression simExpr, String relOp, ExpressionStatement expr) {
     this.simExpression = simExpr;
     this.relOperator = relOp;
     this.exprStatement = expr;

--- a/src/Compiler.java
+++ b/src/Compiler.java
@@ -271,7 +271,7 @@ public class Compiler {
        lexer.token == Symbol.GT   ||
        lexer.token == Symbol.GTE) {
 
-      RelationalOperator relOp = relationalOperator();
+      String relOp = relationalOperator();
       ExpressionStatement expr = expression();
     }
     return new ExpressionStatement(simExpr, relOp, expr);


### PR DESCRIPTION
Relational Operator is actually a String. We don't need a class for it
